### PR TITLE
Use `build.failBuild()`

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -18,7 +18,7 @@ function netlifyPlugin(conf) {
       utils: { build }
     }) {
       if (!checkPaths) {
-        throw new Error(
+        build.failBuild(
           `checkPaths is undefined - please specify some checkPaths`
         );
       }


### PR DESCRIPTION
Errors thrown in event handlers are reported as bugs. The `build.failBuild()` can be used though to report user errors. This PR fixes one instance where the error came from the user.