### PR TITLE
Remove `name` from plugin properties

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -11,7 +11,6 @@ const pluginCore = require('./pluginCore');
 
 function netlifyPlugin(conf) {
   return {
-    name: 'netlify-plugin-a11y',
     async onPostBuild({
       pluginConfig: { checkPaths, resultMode = 'error', debugMode },
       constants: { PUBLISH_DIR },


### PR DESCRIPTION
The `name` in plugin properties has been moved to the `name` in `manifest.yml`.