### PR TITLE
Use a plain object instead of a top-level function

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -9,8 +9,7 @@ const pa11y = require('pa11y');
 const path = require('path');
 const pluginCore = require('./pluginCore');
 
-function netlifyPlugin(conf) {
-  return {
+module.exports = {
     name: 'netlify-plugin-a11y',
     async onPostBuild({
       pluginConfig: { checkPaths, resultMode = 'error', debugMode },
@@ -74,7 +73,4 @@ function netlifyPlugin(conf) {
         }
       }
     }
-  };
 }
-
-module.exports = netlifyPlugin;


### PR DESCRIPTION
Plugins can be top-level functions, but this can simplified to a plain object instead in this plugin's case.