### PR TITLE
Comment `testMode` input

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,4 +3,4 @@ inputs:
   - name: checkPaths
   - name: resultMode
   - name: debugMode
-  - name: testMode
+# - name: testMode


### PR DESCRIPTION
This comments the `testMode` input so it is not exposed to users in Netlify UI since this input is currently not used.