### PR TITLE
Add default inputs

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,5 +2,7 @@ name: netlify-plugin-axe
 inputs:
   - name: checkPaths
   - name: resultMode
+    default: error
   - name: debugMode
+    defaut: false
   - name: testMode

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -13,7 +13,7 @@ function netlifyPlugin(conf) {
   return {
     name: 'netlify-plugin-a11y',
     async onPostBuild({
-      pluginConfig: { checkPaths, resultMode = 'error', debugMode },
+      pluginConfig: { checkPaths, resultMode, debugMode },
       constants: { PUBLISH_DIR },
       utils: { build }
     }) {


### PR DESCRIPTION
The `default` field in `manifest.yml` is now available to declare and assign inputs default value, so they can be displayed in the Netlify UI.