### PR TITLE
Fix `name` in `manifest.yml`

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
-name: netlify-plugin-axe
+name: netlify-plugin-a11y
 inputs:
   - name: checkPaths
   - name: resultMode


### PR DESCRIPTION
The `name` in `manifest.yml` has a typo.