### PR TITLE
Remove unused dependency `make-dir`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4953,6 +4953,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
       "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -4960,7 +4961,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "plugin/index.js",
   "dependencies": {
     "chalk": "^3.0.0",
-    "make-dir": "^3.0.0",
     "pa11y": "^5.3.0"
   },
   "scripts": {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -4,8 +4,6 @@
 // } = require('process');
 
 const chalk = require('chalk');
-const makeDir = require('make-dir');
-const pa11y = require('pa11y');
 const path = require('path');
 const pluginCore = require('./pluginCore');
 


### PR DESCRIPTION
This removes `make-dir` which is currently not used.

This PR also removes a variable `pa11y` that is not used in this file.