### PR TITLE
Fix HTML crawling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5536,6 +5536,11 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -5550,8 +5555,7 @@
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
-      "dev": true
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -5784,6 +5788,14 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "requires": {
+        "picomatch": "^2.2.1"
       }
     },
     "realpath-native": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "plugin/index.js",
   "dependencies": {
     "chalk": "^3.0.0",
-    "pa11y": "^5.3.0"
+    "pa11y": "^5.3.0",
+    "path-type": "^4.0.0",
+    "readdirp": "^3.4.0"
   },
   "scripts": {
     "build": "netlify build",

--- a/plugin/pluginCore.js
+++ b/plugin/pluginCore.js
@@ -2,7 +2,7 @@ const { extname } = require('path')
 
 const pa11y = require('pa11y');
 const readdirp = require('readdirp')
-const { isDirectory } = require('path-type')
+const { isDirectory, isFile } = require('path-type')
 
 exports.runPa11y = async function({ htmlFilePaths, testMode, debugMode }) {
   let results = await Promise.all(htmlFilePaths.map(pa11y));
@@ -41,6 +41,11 @@ const findHtmlFiles = async function(fileAndDirPath) {
   if (await isDirectory(fileAndDirPath)) {
     const fileInfos = await readdirp.promise(fileAndDirPath, { fileFilter: '*.html' })
     return fileInfos.map(({ fullPath }) => fullPath)
+  }
+
+  if (!(await isFile(fileAndDirPath))) {
+    console.warn(`Folder ${fileAndDirPath} was provided in "checkPaths", but does not exist - it either indicates something went wrong with your build, or you can simply delete this folder from your "checkPaths" in netlify.toml`)
+    return []
   }
 
   if (extname(fileAndDirPath) !== '.html') {

--- a/plugin/pluginCore.js
+++ b/plugin/pluginCore.js
@@ -1,9 +1,8 @@
-const pa11y = require('pa11y');
-const path = require('path');
-const fs = require('fs');
+const { extname } = require('path')
 
-const { promisify } = require('util');
-const readDir = promisify(fs.readdir);
+const pa11y = require('pa11y');
+const readdirp = require('readdirp')
+const { isDirectory } = require('path-type')
 
 exports.runPa11y = async function({ htmlFilePaths, testMode, debugMode }) {
   let results = await Promise.all(htmlFilePaths.map(pa11y));
@@ -32,34 +31,24 @@ exports.generateFilePaths = async function({
   testMode,
   debugMode
 }) {
-  let htmlFilePaths = [];
-  for (fileAndDirPath of fileAndDirPaths) {
-    const fullDirPath = path.join(PUBLISH_DIR, fileAndDirPath);
-    if (fs.statSync(fullDirPath).isDirectory()) {
-      let subPaths = await walk(fullDirPath);
-      htmlFilePaths = htmlFilePaths.concat(subPaths);
-    } else {
-      htmlFilePaths.push(fullDirPath);
-    }
-  }
-  return htmlFilePaths;
+  const htmlFilePaths = await Promise.all(
+    fileAndDirPaths.map(fileAndDirPath => findHtmlFiles(`${PUBLISH_DIR}/${fileAndDirPath}`))
+  )
+  return [].concat(...htmlFilePaths)
 };
 
-var walk = async function(dir, filelist) {
-  var files = await readDir(dir);
-  filelist = filelist || [];
-  await Promise.all(
-    files.map(async function(file) {
-      const dirfile = path.join(dir, file);
-      if (fs.statSync(dirfile).isDirectory()) {
-        filelist = await walk(dirfile + '/', filelist);
-      } else {
-        if (dirfile.endsWith('.html')) filelist.push(dirfile);
-      }
-    })
-  );
-  return filelist;
-};
+const findHtmlFiles = async function(fileAndDirPath) {
+  if (await isDirectory(fileAndDirPath)) {
+    const fileInfos = await readdirp.promise(fileAndDirPath, { fileFilter: '*.html' })
+    return fileInfos.map(({ fullPath }) => fullPath)
+  }
+
+  if (extname(fileAndDirPath) !== '.html') {
+    return []
+  }
+
+  return [fileAndDirPath]
+}
 
 //  res:
 //    [ { code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H37',


### PR DESCRIPTION
Fixes #19.

HTML crawling fails when one of the paths passed as `checkPaths` does not exist.

This PR also makes the crawling happen in parallel for all `checkPaths` (instead of serially) and replace custom crawling by the `readdirp` library.