### PR TITLE
allow explicitly ignoring directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ package = "netlify-plugin-a11y"
   ]
   
   # # optional config
+  # ignoreDirectories = ['/admin']  # explicitly ignore these directories
+
   # resultMode = "warn" # is "error" by default
 
   # # Developer only

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,8 @@ name: netlify-plugin-a11y
 inputs:
   - name: checkPaths
     required: true
+  - name: ignoreDirectories
+    required: false
   - name: resultMode
     default: error
   - name: debugMode

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -9,12 +9,13 @@ const pluginCore = require('./pluginCore');
 
 module.exports = {
     async onPostBuild({
-      inputs: { checkPaths, resultMode, debugMode },
+      inputs: { checkPaths, ignoreDirectories, resultMode, debugMode },
       constants: { PUBLISH_DIR },
       utils: { build }
     }) {
       const htmlFilePaths = await pluginCore.generateFilePaths({
         fileAndDirPaths: checkPaths,
+        ignoreDirectories: ignoreDirectories || [],
         PUBLISH_DIR
       });
       if (debugMode) {

--- a/plugin/pluginCore.js
+++ b/plugin/pluginCore.js
@@ -27,19 +27,29 @@ exports.runPa11y = async function({ htmlFilePaths, testMode, debugMode }) {
 
 exports.generateFilePaths = async function({
   fileAndDirPaths, // array, mix of html and directories
+  ignoreDirectories = [],
   PUBLISH_DIR,
   testMode,
   debugMode
 }) {
+  const excludeDirGlobs = ignoreDirectories.map(
+    // add ! and strip leading slash
+    (dir) => `!${dir.replace(/^\/+/, "")}`
+  );
   const htmlFilePaths = await Promise.all(
-    fileAndDirPaths.map(fileAndDirPath => findHtmlFiles(`${PUBLISH_DIR}/${fileAndDirPath}`))
+    fileAndDirPaths.map(fileAndDirPath =>
+      findHtmlFiles(`${PUBLISH_DIR}${fileAndDirPath}`, excludeDirGlobs)
+    )
   )
   return [].concat(...htmlFilePaths)
 };
 
-const findHtmlFiles = async function(fileAndDirPath) {
+const findHtmlFiles = async function (fileAndDirPath, directoryFilter) {
   if (await isDirectory(fileAndDirPath)) {
-    const fileInfos = await readdirp.promise(fileAndDirPath, { fileFilter: '*.html' })
+    const fileInfos = await readdirp.promise(fileAndDirPath, {
+      fileFilter: '*.html',
+      directoryFilter
+    })
     return fileInfos.map(({ fullPath }) => fullPath)
   }
 

--- a/tests/generateFilePaths/publishDir/admin/index.html
+++ b/tests/generateFilePaths/publishDir/admin/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
+  </head>
+  <body></body>
+</html>

--- a/tests/generateFilePaths/this.test.js
+++ b/tests/generateFilePaths/this.test.js
@@ -11,3 +11,31 @@ test('generateFilePaths works', async () => {
   });
   expect(results).toMatchSnapshot();
 });
+
+const pathInResults = (expectedPath, results) => {
+  return results.findIndex((r) => r.endsWith(expectedPath)) != -1;
+};
+
+test("ignoreDirectories works including leading slash", async () => {
+  const results = await pluginCore.generateFilePaths({
+    fileAndDirPaths: ["/"],
+    ignoreDirectories: ["/admin"],
+    PUBLISH_DIR,
+  });
+  expect(pathInResults("publishDir/blog/post1.html", results)).toBe(true);
+  expect(pathInResults("publishDir/about.html", results)).toBe(true);
+  expect(pathInResults("publishDir/index.html", results)).toBe(true);
+  expect(pathInResults("publishDir/admin/index.html", results)).toBe(false);
+});
+
+test("ignoreDirectories works without leading slash", async () => {
+  const results = await pluginCore.generateFilePaths({
+    fileAndDirPaths: ["/"],
+    ignoreDirectories: ["admin"],
+    PUBLISH_DIR,
+  });
+  expect(pathInResults("publishDir/blog/post1.html", results)).toBe(true);
+  expect(pathInResults("publishDir/about.html", results)).toBe(true);
+  expect(pathInResults("publishDir/index.html", results)).toBe(true);
+  expect(pathInResults("publishDir/admin/index.html", results)).toBe(false);
+});


### PR DESCRIPTION
Add option to explicitly ignore folders from being checked.

My use case is for the netlify-cms plugin with a gatsby project. It automatically includes a bunch of files under /admin that I don't want to check, but I do want to check every other page on the site.

With these changes, I would configure the plugin like this:
```
[plugins.inputs]
checkPaths = ['/']
ignoreDirectories = ['/admin']
```