### PR TITLE
Improve error handling

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -22,6 +22,7 @@ module.exports = {
       }
       const results = await pluginCore.runPa11y({
         htmlFilePaths,
+        build,
         debugMode
       });
 

--- a/plugin/pluginCore.js
+++ b/plugin/pluginCore.js
@@ -4,8 +4,8 @@ const pa11y = require('pa11y');
 const readdirp = require('readdirp')
 const { isDirectory, isFile } = require('path-type')
 
-exports.runPa11y = async function({ htmlFilePaths, testMode, debugMode }) {
-  let results = await Promise.all(htmlFilePaths.map(pa11y));
+exports.runPa11y = async function({ htmlFilePaths, build, testMode, debugMode }) {
+  let results = await Promise.all(htmlFilePaths.map(htmlFilePath => runPa11yOnFile(htmlFilePath, build)));
   results = results
     .filter((res) => res.issues.length)
     .map((res) =>
@@ -24,6 +24,14 @@ exports.runPa11y = async function({ htmlFilePaths, testMode, debugMode }) {
   }
   return flattenedResults;
 };
+
+const runPa11yOnFile = async function(htmlFilePath, build) {
+  try {
+    return await pa11y(htmlFilePath)
+  } catch (error) {
+    build.failBuild(`pa11y failed`, { error })
+  }
+}
 
 exports.generateFilePaths = async function({
   fileAndDirPaths, // array, mix of html and directories

--- a/tests/runPa11y/this.test.js
+++ b/tests/runPa11y/this.test.js
@@ -5,7 +5,8 @@ const path = require('path');
 const pluginCore = require('../../plugin/pluginCore.js');
 test('runPa11y works', async () => {
   const results = await pluginCore.runPa11y({
-    htmlFilePaths: [path.join(__dirname, 'publishDir/index.html')]
+    htmlFilePaths: [path.join(__dirname, 'publishDir/index.html')],
+    build: { failBuild() {} }
   });
   expect(results).toMatchSnapshot();
 });


### PR DESCRIPTION
This adds a `try`/`catch` around `pa11y` so that errors thrown there get reported as user errors.

For example, pa11y can time out.

```
Pa11y timed out (30000ms) 
    /opt/build/repo/node_modules/p-timeout/index.js:27:54 Timeout.setTimeout [as _onTimeout]
```