### PR TITLE
Add default value for `checkPaths` input

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,8 @@
 name: netlify-plugin-a11y
 inputs:
   - name: checkPaths
-    required: true
+    default: ['/']
+    required: false
   - name: ignoreDirectories
     required: false
   - name: resultMode


### PR DESCRIPTION
This adds a default value for the `checkPaths` input, so that this plugin can be used without adding any configuration. This is especially important when installed from the Netlify UI.