### PR TITLE
Add option to override timeouts for larger scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ If you've installed the plugin via `netlify.toml`, you can add a `[[plugins.inpu
 | `ignoreElements`    | Indicates elements that should be ignored by a11y testing                                            | String (CSS selector) | Comma-separated string of CSS selectors       | `undefined`   |
 | `ignoreGuidelines`  | Indicates guidelines and types to ignore ([pa11y docs](https://github.com/pa11y/pa11y#ignore-array)) | Array of strings      | Comma-separated string of WCAG Guidlines      | `[]`          |
 | `wcagLevel`         | The WCAG standard level against which pages are checked                                              | String                | `'WCAG2A'` or `'WCAGA2A'` or `'WCAG2AAA'`     | `'WCAG2AA'`   |
+| `timeout`           | Amount of time, in milliseconds, the scan will run before timing out.                                | Number               | Any positive integer                          | 60000         |
 
 Here's how these inputs can be used in `netlify.toml`, with comments to explain how each input affects the plugin's behavior:
 
@@ -119,4 +120,6 @@ Here's how these inputs can be used in `netlify.toml`, with comments to explain 
     ignoreGuidelines = ['WCAG2AA.Principle1.Guideline1_4.1_4_6.G17']
     # Perform a11y check against WCAG 2.1 AAA
     wcagLevel = 'WCAG2AAA'
+    # Extends the timeout of the scan to 2 minutes (120000ms)
+    timeout = 120000
 ```

--- a/manifest.yml
+++ b/manifest.yml
@@ -16,3 +16,6 @@ inputs:
   - name: wcagLevel
     default: 'WCAG2AA'
     description: The level of WCAG 2.1 against which to check site pages. Defaults to 'WCAGAA'; can also be 'WCAGA' or 'WCAGAAA'.
+  - name: timeout
+    default: 60000
+    description: Amount of time, in milliseconds, the scan will run before timing out. Defaults to 60000.

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,11 +10,13 @@ type InputT = {
 	ignoreGuidelines?: string[],
 	failWithIssues?: boolean,
 	wcagLevel?: WCAGLevel,
+	timeout?: number,
 }
 
 const DEFAULT_CHECK_PATHS = ['/']
 const DEFAULT_FAIL_WITH_ISSUES = true
 const DEFAULT_IGNORE_DIRECTORIES: string[] = []
+const DEFAULT_TIMEOUT: number = 60000
 
 const PA11Y_DEFAULT_WCAG_LEVEL = 'WCAG2AA'
 const PA11Y_RUNNERS = ['axe']
@@ -24,7 +26,7 @@ export const getConfiguration = async ({
 	constants: { PUBLISH_DIR },
 	inputs,
 }: Pick<NetlifyPluginOptions, 'constants' | 'inputs'>) => {
-	const { checkPaths, ignoreDirectories, ignoreElements, ignoreGuidelines, failWithIssues, wcagLevel } =
+	const { checkPaths, ignoreDirectories, ignoreElements, ignoreGuidelines, failWithIssues, wcagLevel, timeout } =
 		inputs as InputT
 	return {
 		checkPaths: checkPaths || DEFAULT_CHECK_PATHS,
@@ -34,6 +36,7 @@ export const getConfiguration = async ({
 			hideElements: ignoreElements,
 			ignore: ignoreGuidelines,
 			standard: wcagLevel || PA11Y_DEFAULT_WCAG_LEVEL,
+			timeout: timeout || DEFAULT_TIMEOUT,
 		}),
 		publishDir: (PUBLISH_DIR || process.env.PUBLISH_DIR) as string,
 	}
@@ -41,7 +44,7 @@ export const getConfiguration = async ({
 
 export type Config = ReturnType<typeof getConfiguration>
 
-export const getPa11yOpts = async ({ hideElements, ignore, standard }: { hideElements?: string; ignore?: string[]; standard: WCAGLevel }) => {
+export const getPa11yOpts = async ({ hideElements, ignore, standard, timeout }: { hideElements?: string; ignore?: string[]; standard: WCAGLevel, timeout: number }) => {
 	return {
 		browser: await puppeteer.launch({ ignoreHTTPSErrors: true }),
 		hideElements,
@@ -49,6 +52,7 @@ export const getPa11yOpts = async ({ hideElements, ignore, standard }: { hideEle
 		runners: PA11Y_RUNNERS,
 		userAgent: PA11Y_USER_AGENT,
 		standard,
+		timeout,
 	}
 }
 


### PR DESCRIPTION
Adds an option to override pa11y's (and puppeteer's) default timeout

Sort of a stop-gap solution for the issue discussed in #5. Obviously, more parallel processing would be a better way to handle large sites, but this would at least allow medium-sized sites to bump up the timeout and still be able to scan everything