### PR TITLE
Fix issue with scanning subfolders if ignoreDirectories is not used

### DIFF
--- a/plugin/pluginCore.js
+++ b/plugin/pluginCore.js
@@ -56,7 +56,7 @@ const findHtmlFiles = async function (fileAndDirPath, directoryFilter) {
   if (await isDirectory(fileAndDirPath)) {
     const fileInfos = await readdirp.promise(fileAndDirPath, {
       fileFilter: '*.html',
-      directoryFilter
+      directoryFilter: !!directoryFilter.length ? directoryFilter : '*'
     })
     return fileInfos.map(({ fullPath }) => fullPath)
   }


### PR DESCRIPTION
I noticed that if I did not set `ignoreDirectories`...
```toml
[plugins.inputs]
  checkPaths = ['/']
  # ignoreDirectories = ['/admin']
  resultMode = "warn"
```
...then none of the subfolders were being scanned. This appears to be because `directoryFilter` can be used [both exclusively and inclusively](https://www.npmjs.com/package/readdirp#options).

When used with `ignoreDirectories`, it was being interpreted as "exclude these paths" (as expected), but if it was not set, it was being interpreted as "include no paths"