### PR TITLE
Bugfix: pa11y requires absolute paths for local files

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -10,13 +10,13 @@ const pluginCore = require('./pluginCore');
 module.exports = {
     async onPostBuild({
       inputs: { checkPaths, ignoreDirectories, resultMode, debugMode },
-      constants: { PUBLISH_DIR },
-      utils: { build }
+      utils: { build },
+      netlifyConfig
     }) {
       const htmlFilePaths = await pluginCore.generateFilePaths({
         fileAndDirPaths: checkPaths,
         ignoreDirectories: ignoreDirectories || [],
-        PUBLISH_DIR
+        absolutePublishDir: netlifyConfig.build.publish
       });
       if (debugMode) {
         console.log({ htmlFilePaths });

--- a/plugin/pluginCore.js
+++ b/plugin/pluginCore.js
@@ -36,7 +36,7 @@ const runPa11yOnFile = async function(htmlFilePath, build) {
 exports.generateFilePaths = async function({
   fileAndDirPaths, // array, mix of html and directories
   ignoreDirectories = [],
-  PUBLISH_DIR,
+  absolutePublishDir,
   testMode,
   debugMode
 }) {
@@ -46,7 +46,7 @@ exports.generateFilePaths = async function({
   );
   const htmlFilePaths = await Promise.all(
     fileAndDirPaths.map(fileAndDirPath =>
-      findHtmlFiles(`${PUBLISH_DIR}${fileAndDirPath}`, excludeDirGlobs)
+      findHtmlFiles(`${absolutePublishDir}${fileAndDirPath}`, excludeDirGlobs)
     )
   )
   return [].concat(...htmlFilePaths)


### PR DESCRIPTION
See also: https://github.com/pa11y/pa11y
PUBLISH_DIR is a relative path. This changes it to use the config to get
the absolute path.