### PR TITLE
Change standard input to wcagLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you've installed the plugin via `netlify.toml`, you can add a `[[plugins.inpu
 | `checkPaths`        	| An array of strings indicating which pages of your site to check.            	| Any directories or html files in your project 	| `['/']`       	|
 | `failWithIssues`    	| A boolean indicating whether the build should fail if a11y issues are found. 	| `true` or `false`                             	| `true`        	|
 | `ignoreDirectories` 	| An array of directories that *should not* be checked for a11y issues.        	| Any directories within your project           	| `[]`          	|
-| `standard`          	| The WCAG standard level against which pages are checked.                     	| `'WCAGA'` or `'WCAGAA'` or `'WCAGAAA'`        	| `'WCAGAA'`    	|
+| `wcagLevel`          	| The WCAG standard level against which pages are checked.                     	| `'WCAGA'` or `'WCAGAA'` or `'WCAGAAA'`        	| `'WCAGAA'`    	|
 
 Here's how these inputs can be used in `netlify.toml`, with comments to explain how each input affects the plugin's behavior:
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,6 @@ inputs:
   - name: ignoreDirectories
     default: []
     description: Array of directories whose pages the plugin should ignore when checking for a11y issues. Defaults to [].
-  - name: standard
+  - name: wcagLevel
     default: 'WCAG2AA'
     description: The level of WCAG 2.1 against which to check site pages. Defaults to 'WCAGAA'; can also be 'WCAGA' or 'WCAGAAA'.

--- a/src/config.js
+++ b/src/config.js
@@ -4,13 +4,13 @@ const DEFAULT_CHECK_PATHS = ['/']
 const DEFAULT_FAIL_WITH_ISSUES = true
 const DEFAULT_IGNORE_DIRECTORIES = []
 
-const PA11Y_DEFAULT_STANDARD = 'WCAG2AA'
+const PA11Y_DEFAULT_WCAG_LEVEL = 'WCAG2AA'
 const PA11Y_RUNNERS = ['axe']
 const PA11Y_USER_AGENT = 'netlify-plugin-a11y'
 
 const getConfiguration = ({
 	constants: { PUBLISH_DIR },
-	inputs: { checkPaths, ignoreDirectories, failWithIssues, standard },
+	inputs: { checkPaths, ignoreDirectories, failWithIssues, wcagLevel },
 }) => {
 	return {
 		absolutePublishDir: PUBLISH_DIR || process.env.PUBLISH_DIR,
@@ -20,7 +20,7 @@ const getConfiguration = ({
 		pa11yOpts: {
 			runners: PA11Y_RUNNERS,
 			userAgent: PA11Y_USER_AGENT,
-			standard: standard || PA11Y_DEFAULT_STANDARD,
+			standard: wcagLevel || PA11Y_DEFAULT_WCAG_LEVEL,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
Changes the name of the `standard` input to `wcagLevel`, to better reflect what the input does, and to disambiguate it from the many possible meanings of 'standard'.