### PR TITLE
Add custom results reporter

### DIFF
--- a/src/pluginCore.js
+++ b/src/pluginCore.js
@@ -3,7 +3,7 @@
 const pa11y = require('pa11y')
 const { extname } = require('path')
 const { isDirectory, isFile } = require('path-type')
-const { results: cliReporter } = require('pa11y/lib/reporters/cli')
+const { results: cliReporter } = require('./reporter')
 const readdirp = require('readdirp')
 
 const EMPTY_ARRAY = []

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -10,6 +10,9 @@
 
 const { cyan, green, gray, red, underline, yellow } = require('picocolors')
 
+// Pa11y version support
+const PA11Y_SUPPORTS = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta'
+
 const DUPLICATE_WHITESPACE_EXP = /\s+/g
 const EMPTY_SPACE = ' '
 const NEWLINE_LITERAL = '\n'
@@ -17,6 +20,7 @@ const NEWLINE_LITERAL = '\n'
 const rootFilePath = 'file://' + process.cwd()
 
 // Helper strings for use in reporter methods
+const start = cyan(' >')
 const typeIndicators = {
 	error: red(' • Error:'),
 	notice: cyan(' • Notice:'),
@@ -79,6 +83,37 @@ function renderResults(results) {
 	`)
 }
 
+// Output the welcome message once Pa11y begins testing
+function renderBegin() {
+	return cleanWhitespace(`
+		${cyan(underline('Welcome to Pa11y'))}
+	`)
+}
+
+// Output debug messages
+function renderDebug(message) {
+	message = `Debug: ${message}`
+	return cleanWhitespace(`
+		${start} ${gray(message)}
+	`)
+}
+
+// Output information messages
+function renderInfo(message) {
+	return cleanWhitespace(`
+		${start} ${message}
+	`)
+}
+
+function renderError(message) {
+	if (!/^error:/i.test(message)) {
+		message = `Error: ${message}`
+	}
+	return cleanWhitespace(`
+		${red(message)}
+	`)
+}
+
 // Clean whitespace from output. This function is used to keep
 // the reporter code a little cleaner
 function cleanWhitespace(string) {
@@ -89,11 +124,11 @@ function pluralize(noun, count) {
 	return count === 1 ? noun : noun + 's'
 }
 
-const reporter = {}
-
-// Pa11y version support
-reporter.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta'
-
-reporter.results = renderResults
-
-module.exports = reporter
+module.exports = {
+	begin: renderBegin,
+	debug: renderDebug,
+	info: renderInfo,
+	error: renderError,
+	results: renderResults,
+	supports: PA11Y_SUPPORTS,
+}

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,4 +1,11 @@
+/**
+ * This reporter is adapted from the CLI reporter built into the pa11y library,
+ * with some small differences for performance reasons.
+ *
+ * @see https://github.com/pa11y/pa11y/blob/6.1.1/lib/reporters/cli.js
+ */
 // @ts-check
+
 'use strict'
 
 const { cyan, green, gray, red, underline, yellow } = require('picocolors')

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,3 +1,4 @@
+// @ts-check
 'use strict'
 
 const { cyan, green, gray, red, underline, yellow } = require('picocolors')
@@ -7,27 +8,23 @@ const EMPTY_SPACE = ' '
 const NEWLINE_LITERAL = '\n'
 
 const rootFilePath = 'file://' + process.cwd()
-const reporter = {}
-
-// Pa11y version support
-reporter.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta'
 
 // Helper strings for use in reporter methods
-const typeStarts = {
+const typeIndicators = {
 	error: red(' • Error:'),
 	notice: cyan(' • Notice:'),
 	unknown: gray(' •'),
 	warning: yellow(' • Warning:'),
 }
 
-function generateReadableIssue(issue) {
+function renderIssue(issue) {
 	const code = issue.code
 	const selector = issue.selector.replace(DUPLICATE_WHITESPACE_EXP, EMPTY_SPACE)
 	const context = issue.context ? issue.context.replace(DUPLICATE_WHITESPACE_EXP, EMPTY_SPACE) : '[no context]'
 
 	return cleanWhitespace(`
 
-	${typeStarts[issue.type]} ${issue.message}
+	${typeIndicators[issue.type]} ${issue.message}
 		${gray(`├── ${code}`)}
 		${gray(`├── ${selector}`)}
 		${gray(`└── ${context}`)}
@@ -35,7 +32,7 @@ function generateReadableIssue(issue) {
 }
 
 // Output formatted results
-function generateReadableResults(results) {
+function renderResults(results) {
 	const relativeFilePath = results.pageUrl.replace(rootFilePath, '.')
 	if (results.issues.length) {
 		const totals = {
@@ -47,7 +44,7 @@ function generateReadableResults(results) {
 		const summary = []
 
 		for (const issue of results.issues) {
-			issues.push(generateReadableIssue(issue))
+			issues.push(renderIssue(issue))
 			totals[issue.type] = totals[issue.type] + 1
 		}
 
@@ -85,6 +82,11 @@ function pluralize(noun, count) {
 	return count === 1 ? noun : noun + 's'
 }
 
-reporter.results = generateReadableResults
+const reporter = {}
+
+// Pa11y version support
+reporter.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta'
+
+reporter.results = renderResults
 
 module.exports = reporter

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const { cyan, green, gray, red, underline, yellow } = require('picocolors')
+
+const DUPLICATE_WHITESPACE_EXP = /\s+/g
+const EMPTY_SPACE = ' '
+const NEWLINE_LITERAL = '\n'
+
+const rootFilePath = 'file://' + process.cwd()
+const reporter = {}
+
+// Pa11y version support
+reporter.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta'
+
+// Helper strings for use in reporter methods
+const typeStarts = {
+	error: red(' • Error:'),
+	notice: cyan(' • Notice:'),
+	unknown: gray(' •'),
+	warning: yellow(' • Warning:'),
+}
+
+function generateReadableIssue(issue) {
+	const code = issue.code
+	const selector = issue.selector.replace(DUPLICATE_WHITESPACE_EXP, EMPTY_SPACE)
+	const context = issue.context ? issue.context.replace(DUPLICATE_WHITESPACE_EXP, EMPTY_SPACE) : '[no context]'
+
+	return cleanWhitespace(`
+
+	${typeStarts[issue.type]} ${issue.message}
+		${gray(`├── ${code}`)}
+		${gray(`├── ${selector}`)}
+		${gray(`└── ${context}`)}
+	`)
+}
+
+// Output formatted results
+function generateReadableResults(results) {
+	const relativeFilePath = results.pageUrl.replace(rootFilePath, '.')
+	if (results.issues.length) {
+		const totals = {
+			error: 0,
+			notice: 0,
+			warning: 0,
+		}
+		const issues = []
+		const summary = []
+
+		for (const issue of results.issues) {
+			issues.push(generateReadableIssue(issue))
+			totals[issue.type] = totals[issue.type] + 1
+		}
+
+		if (totals.error > 0) {
+			summary.push(red(`${totals.error} ${pluralize('Error', totals.error)}`))
+		}
+		if (totals.warning > 0) {
+			summary.push(yellow(`${totals.warning} ${pluralize('Warning', totals.warning)}`))
+		}
+		if (totals.notice > 0) {
+			summary.push(cyan(`${totals.notice} ${pluralize('Notice', totals.notice)}`))
+		}
+
+		return cleanWhitespace(`
+
+			${underline(`Results for file: ${relativeFilePath}`)}
+			${issues.join(NEWLINE_LITERAL)}
+
+			${summary.join(NEWLINE_LITERAL)}
+
+		`)
+	}
+	return cleanWhitespace(`
+		${green('No issues found!')}
+	`)
+}
+
+// Clean whitespace from output. This function is used to keep
+// the reporter code a little cleaner
+function cleanWhitespace(string) {
+	return string.replace(/\t+|^\t*\n|\n\t*$/g, '')
+}
+
+function pluralize(noun, count) {
+	return count === 1 ? noun : noun + 's'
+}
+
+reporter.results = generateReadableResults
+
+module.exports = reporter


### PR DESCRIPTION
## Summary
Adds our own results reporter based on pa11y's implementation. Differences: 

- swaps `kleur` for `picocolors` since we're already using it.
- rewrites `renderResults` to print only the relative path of a file
- eliminates many duplicate iteration operations present in pa11y implementation