### PR TITLE
Use relative file paths

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ const getConfiguration = ({
 	inputs: { checkPaths, ignoreDirectories, failWithIssues, wcagLevel },
 }) => {
 	return {
-		absolutePublishDir: PUBLISH_DIR || process.env.PUBLISH_DIR,
+		publishDir: PUBLISH_DIR || process.env.PUBLISH_DIR,
 		checkPaths: checkPaths || DEFAULT_CHECK_PATHS,
 		ignoreDirectories: ignoreDirectories || DEFAULT_IGNORE_DIRECTORIES,
 		failWithIssues: failWithIssues !== undefined ? failWithIssues : DEFAULT_FAIL_WITH_ISSUES,

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,12 @@ const pico = require('picocolors')
 module.exports = {
 	async onPostBuild({ constants, inputs, utils: { build } }) {
 		try {
-			const { absolutePublishDir, checkPaths, ignoreDirectories, pa11yOpts, failWithIssues } = getConfiguration({
+			const { publishDir, checkPaths, ignoreDirectories, pa11yOpts, failWithIssues } = getConfiguration({
 				constants,
 				inputs,
 			})
 			const htmlFilePaths = await pluginCore.generateFilePaths({
-				absolutePublishDir,
+				publishDir,
 				ignoreDirectories,
 				fileAndDirPaths: checkPaths,
 			})

--- a/src/pluginCore.js
+++ b/src/pluginCore.js
@@ -36,7 +36,7 @@ exports.runPa11y = async function ({ htmlFilePaths, pa11yOpts, build }) {
 exports.generateFilePaths = async function ({
 	fileAndDirPaths, // array, mix of html and directories
 	ignoreDirectories,
-	absolutePublishDir,
+	publishDir,
 }) {
 	const directoryFilter =
 		ignoreDirectories.length === 0
@@ -46,7 +46,7 @@ exports.generateFilePaths = async function ({
 					(dir) => `!${dir.replace(/^\/+/, '')}`,
 			  )
 	const htmlFilePaths = await Promise.all(
-		fileAndDirPaths.map((fileAndDirPath) => findHtmlFiles(`${absolutePublishDir}${fileAndDirPath}`, directoryFilter)),
+		fileAndDirPaths.map((fileAndDirPath) => findHtmlFiles(`${publishDir}${fileAndDirPath}`, directoryFilter)),
 	)
 	return [].concat(...htmlFilePaths)
 }

--- a/src/pluginCore.js
+++ b/src/pluginCore.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const pa11y = require('pa11y')
-const { extname } = require('path')
+const { extname, join } = require('path')
 const { isDirectory, isFile } = require('path-type')
 const { results: cliReporter } = require('./reporter')
 const readdirp = require('readdirp')
@@ -59,8 +59,8 @@ const findHtmlFiles = async function (fileAndDirPath, directoryFilter) {
 			fileFilter: GLOB_HTML,
 		})
 
-		for await (const { fullPath } of stream) {
-			filePaths.push(fullPath)
+		for await (const { path } of stream) {
+			filePaths.push(join(fileAndDirPath, path))
 		}
 
 		return filePaths

--- a/tests/generateFilePaths/__snapshots__/this.test.js.snap
+++ b/tests/generateFilePaths/__snapshots__/this.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`generateFilePaths works 1`] = `
 Array [
-  "/Users/ej/projects/netlify-plugin-a11y/tests/generateFilePaths/publishDir/blog/post1.html",
-  "/Users/ej/projects/netlify-plugin-a11y/tests/generateFilePaths/publishDir/blog/post2.html",
-  "/Users/ej/projects/netlify-plugin-a11y/tests/generateFilePaths/publishDir/about.html",
+  "tests/generateFilePaths/publishDir/blog/post1.html",
+  "tests/generateFilePaths/publishDir/blog/post2.html",
+  "tests/generateFilePaths/publishDir/about.html",
 ]
 `;

--- a/tests/generateFilePaths/this.test.js
+++ b/tests/generateFilePaths/this.test.js
@@ -7,7 +7,7 @@ const publishDir = path.relative(process.cwd(), PUBLISH_DIR)
 const pluginCore = require('../../src/pluginCore')
 test('generateFilePaths works', async () => {
 	const results = await pluginCore.generateFilePaths({
-		absolutePublishDir: publishDir,
+		publishDir: publishDir,
 		fileAndDirPaths: ['/blog', '/about.html'],
 		ignoreDirectories: [],
 	})
@@ -22,7 +22,7 @@ test('ignoreDirectories works including leading slash', async () => {
 	const results = await pluginCore.generateFilePaths({
 		fileAndDirPaths: ['/'],
 		ignoreDirectories: ['/admin'],
-		absolutePublishDir: publishDir,
+		publishDir: publishDir,
 	})
 	expect(pathInResults('publishDir/blog/post1.html', results)).toBe(true)
 	expect(pathInResults('publishDir/about.html', results)).toBe(true)
@@ -34,7 +34,7 @@ test('ignoreDirectories works without leading slash', async () => {
 	const results = await pluginCore.generateFilePaths({
 		fileAndDirPaths: ['/'],
 		ignoreDirectories: ['admin'],
-		absolutePublishDir: publishDir,
+		publishDir: publishDir,
 	})
 	expect(pathInResults('publishDir/blog/post1.html', results)).toBe(true)
 	expect(pathInResults('publishDir/about.html', results)).toBe(true)

--- a/tests/generateFilePaths/this.test.js
+++ b/tests/generateFilePaths/this.test.js
@@ -1,11 +1,13 @@
 const path = require('path')
 
 const PUBLISH_DIR = path.join(__dirname, 'publishDir')
+const publishDir = path.relative(process.cwd(), PUBLISH_DIR)
 // actual test
+
 const pluginCore = require('../../src/pluginCore')
 test('generateFilePaths works', async () => {
 	const results = await pluginCore.generateFilePaths({
-		absolutePublishDir: PUBLISH_DIR,
+		absolutePublishDir: publishDir,
 		fileAndDirPaths: ['/blog', '/about.html'],
 		ignoreDirectories: [],
 	})
@@ -20,7 +22,7 @@ test('ignoreDirectories works including leading slash', async () => {
 	const results = await pluginCore.generateFilePaths({
 		fileAndDirPaths: ['/'],
 		ignoreDirectories: ['/admin'],
-		absolutePublishDir: PUBLISH_DIR,
+		absolutePublishDir: publishDir,
 	})
 	expect(pathInResults('publishDir/blog/post1.html', results)).toBe(true)
 	expect(pathInResults('publishDir/about.html', results)).toBe(true)
@@ -32,7 +34,7 @@ test('ignoreDirectories works without leading slash', async () => {
 	const results = await pluginCore.generateFilePaths({
 		fileAndDirPaths: ['/'],
 		ignoreDirectories: ['admin'],
-		absolutePublishDir: PUBLISH_DIR,
+		absolutePublishDir: publishDir,
 	})
 	expect(pathInResults('publishDir/blog/post1.html', results)).toBe(true)
 	expect(pathInResults('publishDir/about.html', results)).toBe(true)

--- a/tests/runPa11y/__snapshots__/this.test.js.snap
+++ b/tests/runPa11y/__snapshots__/this.test.js.snap
@@ -4,14 +4,14 @@ exports[`runPa11y works 1`] = `
 Object {
   "issueCount": 1,
   "report": "
-[4mResults for URL: file:///Users/ej/projects/netlify-plugin-a11y/tests/runPa11y/publishDir/index.html[24m
+[4mResults for file: ./tests/runPa11y/publishDir/index.html[24m
 
 [31m • Error:[39m Img element missing an alt attribute. Use the alt attribute to specify a short text alternative.
-   [90m├── WCAG2AA.Principle1.Guideline1_1.1_1_1.H37[39m
-   [90m├── html > body > img[39m
-   [90m└── <img src=\\"https://placekitten.com/200/300\\">[39m
+[90m├── WCAG2AA.Principle1.Guideline1_1.1_1_1.H37[39m
+[90m├── html > body > img[39m
+[90m└── <img src=\\"https://placekitten.com/200/300\\">[39m
 
-[31m1 Errors[39m
+[31m1 Error[39m
 ",
 }
 `;

--- a/tests/runPa11y/this.test.js
+++ b/tests/runPa11y/this.test.js
@@ -1,11 +1,11 @@
 const path = require('path')
+const filePath = path.relative(process.cwd(), path.join(__dirname, 'publishDir/index.html'))
 
 // actual test
 const pluginCore = require('../../src/pluginCore')
 test('runPa11y works', async () => {
-	console.log([path.join(__dirname, 'publishDir/index.html')])
 	const results = await pluginCore.runPa11y({
-		htmlFilePaths: [path.join(__dirname, 'publishDir/index.html')],
+		htmlFilePaths: [filePath],
 		build: { failBuild() {} },
 	})
 	expect(results).toMatchSnapshot()


### PR DESCRIPTION
## Summary
- renames internal `absolutePublishDir` string to `publishDir`
- uses relative file paths when traversing directories with readdirp
- uses relative paths in tests, preventing snapshots from leaking any developers' directory structure