### PR TITLE
Added option to ignore guideline codes and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ If you want to use the plugin's default settings (check **all** pages of your si
 If you've installed the plugin via `netlify.toml`, you can add a `[[plugins.inputs]]` field to change how the plugin behaves. This table outlines the inputs the plugin accepts. All of them are optional.
 
 
-| Input name          | Description                                               | Value type            | Possible values                                       | Default value |
-|---------------------|-----------------------------------------------------------|-----------------------|-------------------------------------------------------|---------------|
-| `checkPaths`        | Indicates which pages of your site to check               | Array of strings      | Any directories or HTML files in your project         | `['/']`       |
-| `failWithIssues`    | Whether the build should fail if a11y issues are found    | Boolean               | `true` or `false`                                     | `true`        |
-| `ignoreDirectories` | Directories that *should not* be checked for a11y issues  | Array of strings      | Any directories in your project                       | `[]`          |
-| `ignoreElements`    | Indicates elements that should be ignored by a11y testing | String (CSS selector) | Comma-separated string of CSS selectors               | `undefined`   |
-| `wcagLevel`         | The WCAG standard level against which pages are checked   | String                | `'WCAG2A'` or `'WCAGA2A'` or `'WCAG2AAA'`             | `'WCAG2AA'`   |
+| Input name          | Description                                                                                          | Value type            | Possible values                               | Default value |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | --------------------- | --------------------------------------------- | ------------- |
+| `checkPaths`        | Indicates which pages of your site to check                                                          | Array of strings      | Any directories or HTML files in your project | `['/']`       |
+| `failWithIssues`    | Whether the build should fail if a11y issues are found                                               | Boolean               | `true` or `false`                             | `true`        |
+| `ignoreDirectories` | Directories that *should not* be checked for a11y issues                                             | Array of strings      | Any directories in your project               | `[]`          |
+| `ignoreElements`    | Indicates elements that should be ignored by a11y testing                                            | String (CSS selector) | Comma-separated string of CSS selectors       | `undefined`   |
+| `ignoreGuidelines`  | Indicates guidelines and types to ignore ([pa11y docs](https://github.com/pa11y/pa11y#ignore-array)) | Array of strings      | Comma-separated string of WCAG Guidlines      | `[]`          |
+| `wcagLevel`         | The WCAG standard level against which pages are checked                                              | String                | `'WCAG2A'` or `'WCAGA2A'` or `'WCAG2AAA'`     | `'WCAG2AA'`   |
 
 Here's how these inputs can be used in `netlify.toml`, with comments to explain how each input affects the plugin's behavior:
 
@@ -114,6 +115,8 @@ Here's how these inputs can be used in `netlify.toml`, with comments to explain 
     ignoreDirectories = ['/admin']
     # Ignore any accessibility issues associated with an element matching this selector
     ignoreElements = '.jumbotron > h2'
+    # Ignore any accessibility issues associated with this rule code or type
+    ignoreGuidelines = ['WCAG2AA.Principle1.Guideline1_4.1_4_6.G17']
     # Perform a11y check against WCAG 2.1 AAA
     wcagLevel = 'WCAG2AAA'
 ```

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,6 +11,8 @@ inputs:
     description: Array of directories whose pages the plugin should ignore when checking for a11y issues. Defaults to [].
   - name: ignoreElements
     description: A CSS selector to ignore elements when testing. Accepts multiple comma-separated selectors.
+  - name: ignoreGuidelines
+    description: Ignore any accessibility issues associated with this rule code or type. Accepts multiple comma-separated rules.
   - name: wcagLevel
     default: 'WCAG2AA'
     description: The level of WCAG 2.1 against which to check site pages. Defaults to 'WCAGAA'; can also be 'WCAGA' or 'WCAGAAA'.

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,9 @@ type InputT = {
 	checkPaths?: string[],
 	ignoreDirectories?: string[],
 	ignoreElements?: string,
+	ignoreGuidelines?: string[],
 	failWithIssues?: boolean,
-	wcagLevel?: WCAGLevel
+	wcagLevel?: WCAGLevel,
 }
 
 const DEFAULT_CHECK_PATHS = ['/']
@@ -23,7 +24,7 @@ export const getConfiguration = async ({
 	constants: { PUBLISH_DIR },
 	inputs,
 }: Pick<NetlifyPluginOptions, 'constants' | 'inputs'>) => {
-	const { checkPaths, ignoreDirectories, ignoreElements, failWithIssues, wcagLevel } =
+	const { checkPaths, ignoreDirectories, ignoreElements, ignoreGuidelines, failWithIssues, wcagLevel } =
 		inputs as InputT
 	return {
 		checkPaths: checkPaths || DEFAULT_CHECK_PATHS,
@@ -31,6 +32,7 @@ export const getConfiguration = async ({
 		ignoreDirectories: ignoreDirectories || DEFAULT_IGNORE_DIRECTORIES,
 		pa11yOpts: await getPa11yOpts({
 			hideElements: ignoreElements,
+			ignore: ignoreGuidelines,
 			standard: wcagLevel || PA11Y_DEFAULT_WCAG_LEVEL,
 		}),
 		publishDir: (PUBLISH_DIR || process.env.PUBLISH_DIR) as string,
@@ -39,10 +41,11 @@ export const getConfiguration = async ({
 
 export type Config = ReturnType<typeof getConfiguration>
 
-export const getPa11yOpts = async ({ hideElements, standard }: { hideElements?: string; standard: WCAGLevel }) => {
+export const getPa11yOpts = async ({ hideElements, ignore, standard }: { hideElements?: string; ignore?: string[]; standard: WCAGLevel }) => {
 	return {
 		browser: await puppeteer.launch({ ignoreHTTPSErrors: true }),
 		hideElements,
+		ignore,
 		runners: PA11Y_RUNNERS,
 		userAgent: PA11Y_USER_AGENT,
 		standard,


### PR DESCRIPTION
Pa11y includes the ability to ignore certain guidelines and types - <https://github.com/pa11y/pa11y#ignore-array>. This is really useful when getting a lot of errors around colour contrast due to background images, background gradients or just being unable to determine the background colour, see issue #67 

Ignoring elements isn't great, especially when this is over a large area, eg. entire page has a background gradient, this way you can ignore any colour contrast rules (and check it manually elsewhere), to avoid polluting the deploy logs with false issues (currently have a build that gives 992 errors on one page, the contrast is AAA standard but background is gradient)